### PR TITLE
Add PyYAML to board-cache requirements

### DIFF
--- a/board-cache/requirements.txt
+++ b/board-cache/requirements.txt
@@ -4,3 +4,4 @@ requests
 
 bs4
 htmlmin
+PyYAML


### PR DESCRIPTION
Fixes #16.

`board-cache/config.py` imports `yaml`, but `board-cache/requirements.txt` did not install PyYAML. The root Poetry project already declares `pyyaml`, and other subtools that use YAML either install the root package or already list PyYAML, so this PR keeps the fix scoped to the standalone board-cache requirements file.

Validation:
- Confirmed `board-cache/config.py` imports `yaml`.
- Confirmed `board-cache/requirements.txt` did not list PyYAML before this change.